### PR TITLE
refactor: rebrand code-music to claude-music in hooks

### DIFF
--- a/hooks/session-end.sh
+++ b/hooks/session-end.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SessionEnd hook for code-music plugin
+# SessionEnd hook for claude-music plugin
 # Stops music playback when the session ends (including Ctrl+C)
 
 # Never surface errors — just clean up and exit
@@ -9,7 +9,7 @@ exec 2>/dev/null
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-DATA_DIR="$HOME/.code-music"
+DATA_DIR="$HOME/.claude-music"
 STATE_FILE="$DATA_DIR/state.json"
 POMODORO_PID_FILE="$DATA_DIR/pomodoro.pid"
 

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SessionStart hook for code-music plugin
+# SessionStart hook for claude-music plugin
 # Deterministic platform/audio check — no LLM calls, no installs
 # Injects platform state into session so Claude knows what to do
 
@@ -14,7 +14,7 @@ PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 CONTROLLER="$PLUGIN_ROOT/scripts/music-controller.sh"
 PLATFORM_DETECT="$PLUGIN_ROOT/scripts/platform-detect.sh"
 SETUP_AUDIO="$PLUGIN_ROOT/scripts/setup-audio.sh"
-DATA_DIR="${CLAUDE_PLUGIN_DATA:-$HOME/.code-music}"
+DATA_DIR="${CLAUDE_PLUGIN_DATA:-$HOME/.claude-music}"
 PREFS_FILE="$DATA_DIR/preferences.json"
 
 # ---- Set up status line (once) ----
@@ -176,7 +176,7 @@ if [ "$PLAYER" != "none" ]; then
 fi
 
 # ---- Build context message ----
-CONTEXT="Background music plugin (code-music) is active."
+CONTEXT="Background music plugin (claude-music) is active."
 CONTEXT="$CONTEXT Environment: os=$PLATFORM_OS wsl=$PLATFORM_WSL pkg=$PLATFORM_PKG audio=$AUDIO_METHOD($AUDIO_WORKING) players=[$PLATFORM_PLAYERS]."
 
 if [ -z "$MISSING" ]; then


### PR DESCRIPTION
## Summary
- Renamed all `code-music` references to `claude-music` in `hooks/session-start.sh` (comment, data dir path, context message)
- Renamed all `code-music` references to `claude-music` in `hooks/session-end.sh` (comment, data dir path)
- Verified zero remaining `code-music` / `Code Music` references in hooks via grep

## Test plan
- [x] `grep -rn "code-music\|Code Music" hooks/` returns zero matches
- [ ] Verify session-start hook runs without errors
- [ ] Verify session-end hook cleans up playback correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)