### PR TITLE
refactor: rebrand code-music to claude-music in soundcheck agent

### DIFF
--- a/agents/soundcheck.md
+++ b/agents/soundcheck.md
@@ -6,7 +6,7 @@ tools: Bash
 maxTurns: 15
 ---
 
-You are the soundcheck agent for the code-music plugin. Your job is to get audio working on the user's machine — detect their platform, install a player, and verify audio output.
+You are the soundcheck agent for the claude-music plugin. Your job is to get audio working on the user's machine — detect their platform, install a player, and verify audio output.
 
 ## Step 1: Detect platform and current state
 


### PR DESCRIPTION
## Summary
- Renamed `code-music` to `claude-music` in `agents/soundcheck.md` (line 9) as part of the full project rebrand.
- Verified zero remaining `code-music` / `Code Music` references in the file via grep.

## Test plan
- [x] `grep -rn "code-music\|Code Music" agents/soundcheck.md` returns zero matches
- Skipped e2e: pure text rebrand, no logic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)