### PR TITLE
rename: rebrand skill SKILL.md files from code-music to claude-music (batch B)

### DIFF
--- a/skills/pomodoro/SKILL.md
+++ b/skills/pomodoro/SKILL.md
@@ -7,7 +7,7 @@ effort: low
 allowed-tools: Bash
 ---
 
-This skill is part of the code-music plugin. Only invoke when the user explicitly uses the slash command.
+This skill is part of the claude-music plugin. Only invoke when the user explicitly uses the slash command.
 
 # Pomodoro (alias for /focus)
 

--- a/skills/prefs/SKILL.md
+++ b/skills/prefs/SKILL.md
@@ -7,7 +7,7 @@ effort: low
 allowed-tools: Bash
 ---
 
-This skill is part of the code-music plugin. Only invoke when the user explicitly uses the slash command.
+This skill is part of the claude-music plugin. Only invoke when the user explicitly uses the slash command.
 
 # Preferences
 

--- a/skills/prev/SKILL.md
+++ b/skills/prev/SKILL.md
@@ -7,7 +7,7 @@ effort: low
 allowed-tools: Bash
 ---
 
-This skill is part of the code-music plugin. Only invoke when the user explicitly uses the slash command.
+This skill is part of the claude-music plugin. Only invoke when the user explicitly uses the slash command.
 
 # Previous Station
 

--- a/skills/reset/SKILL.md
+++ b/skills/reset/SKILL.md
@@ -7,7 +7,7 @@ effort: low
 allowed-tools: Bash
 ---
 
-This skill is part of the code-music plugin. Only invoke when the user explicitly uses the slash command.
+This skill is part of the claude-music plugin. Only invoke when the user explicitly uses the slash command.
 
 # Reset Preferences
 

--- a/skills/sources/SKILL.md
+++ b/skills/sources/SKILL.md
@@ -6,15 +6,15 @@ allowed-tools: Bash, Read, Edit, Write
 maxTurns: 8
 ---
 
-This skill is part of the code-music plugin. Only invoke when the user explicitly uses the slash command.
+This skill is part of the claude-music plugin. Only invoke when the user explicitly uses the slash command.
 
 # Sources Manager
 
-Manage the music streams and genres available in the code-music plugin. This is a conversational editor — the user tells you what they want to change and you handle the YAML.
+Manage the music streams and genres available in the claude-music plugin. This is a conversational editor — the user tells you what they want to change and you handle the YAML.
 
 ## Critical Rules
 
-- You are editing the **code-music plugin's** stream configuration and NOTHING else.
+- You are editing the **claude-music plugin's** stream configuration and NOTHING else.
 - The ONLY file you may modify is: `${CLAUDE_PLUGIN_ROOT}/config/sources.yml`
 - NEVER edit, create, or modify any other file on the user's system.
 - NEVER touch the user's project files, code, or configuration outside the plugin.

--- a/skills/stats/SKILL.md
+++ b/skills/stats/SKILL.md
@@ -7,7 +7,7 @@ effort: low
 allowed-tools: Bash
 ---
 
-This skill is part of the code-music plugin. Only invoke when the user explicitly uses the slash command.
+This skill is part of the claude-music plugin. Only invoke when the user explicitly uses the slash command.
 
 # Stats
 

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -7,7 +7,7 @@ effort: low
 allowed-tools: Bash
 ---
 
-This skill is part of the code-music plugin. Only invoke when the user explicitly uses the slash command.
+This skill is part of the claude-music plugin. Only invoke when the user explicitly uses the slash command.
 
 # Music Status
 

--- a/skills/stop/SKILL.md
+++ b/skills/stop/SKILL.md
@@ -7,7 +7,7 @@ effort: low
 allowed-tools: Bash
 ---
 
-This skill is part of the code-music plugin. Only invoke when the user explicitly uses the slash command.
+This skill is part of the claude-music plugin. Only invoke when the user explicitly uses the slash command.
 
 # Stop Music
 
@@ -20,7 +20,7 @@ Run `"${CLAUDE_PLUGIN_ROOT}/scripts/music-controller.sh" stop`.
 
 Output format — use this exact markdown structure:
 
-**♪ Code Music · Session Recap**
+**♪ Claude Music · Session Recap**
 
 **This session** — {genre} for {duration_minutes} min, {station_count} station(s)
 

--- a/skills/vibe/SKILL.md
+++ b/skills/vibe/SKILL.md
@@ -5,7 +5,7 @@ model: sonnet
 allowed-tools: Bash, Agent
 ---
 
-This skill is part of the code-music plugin. Only invoke when the user explicitly uses the slash command.
+This skill is part of the claude-music plugin. Only invoke when the user explicitly uses the slash command.
 
 # Vibe
 

--- a/skills/volume/SKILL.md
+++ b/skills/volume/SKILL.md
@@ -7,7 +7,7 @@ effort: low
 allowed-tools: Bash
 ---
 
-This skill is part of the code-music plugin. Only invoke when the user explicitly uses the slash command.
+This skill is part of the claude-music plugin. Only invoke when the user explicitly uses the slash command.
 
 # Volume
 


### PR DESCRIPTION
## Summary
- Renamed `code-music` to `claude-music` in all 10 skill SKILL.md files (pomodoro, prefs, prev, reset, sources, stats, status, stop, vibe, volume)
- Updated boilerplate line, descriptive references in sources/SKILL.md, and session recap header in stop/SKILL.md
- Verified zero remaining references to `code-music` or `Code Music` in these files

## Test plan
- [x] `grep -rn "code-music\|Code Music"` across all 10 files returns zero matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)