### PR TITLE
refactor: rebrand skills batch A (code-music → claude-music)

### DIFF
--- a/skills/dj/SKILL.md
+++ b/skills/dj/SKILL.md
@@ -5,7 +5,7 @@ model: sonnet
 allowed-tools: Bash, Agent
 ---
 
-This skill is part of the code-music plugin. Only invoke when the user explicitly uses the slash command.
+This skill is part of the claude-music plugin. Only invoke when the user explicitly uses the slash command.
 
 # DJ
 

--- a/skills/feedback/SKILL.md
+++ b/skills/feedback/SKILL.md
@@ -6,7 +6,7 @@ model: haiku
 effort: low
 ---
 
-This skill is part of the code-music plugin. Only invoke when the user explicitly uses the slash command.
+This skill is part of the claude-music plugin. Only invoke when the user explicitly uses the slash command.
 
 # Feedback
 
@@ -17,7 +17,7 @@ Open the GitHub issues page so the user can share feedback or report a bug.
 1. Run this command to open the browser:
 
 ```bash
-xdg-open "https://github.com/kennethleungty/code-music/issues/new" 2>/dev/null || open "https://github.com/kennethleungty/code-music/issues/new" 2>/dev/null
+xdg-open "https://github.com/kennethleungty/claude-music/issues/new" 2>/dev/null || open "https://github.com/kennethleungty/claude-music/issues/new" 2>/dev/null
 ```
 
 2. Tell the user:

--- a/skills/focus/SKILL.md
+++ b/skills/focus/SKILL.md
@@ -7,7 +7,7 @@ effort: low
 allowed-tools: Bash
 ---
 
-This skill is part of the code-music plugin. Only invoke when the user explicitly uses the slash command.
+This skill is part of the claude-music plugin. Only invoke when the user explicitly uses the slash command.
 
 # Focus Timer
 

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -6,11 +6,11 @@ model: haiku
 effort: low
 ---
 
-This skill is part of the code-music plugin. Only invoke when the user explicitly uses the slash command.
+This skill is part of the claude-music plugin. Only invoke when the user explicitly uses the slash command.
 
 # Help
 
-Show the user a quick guide to code-music.
+Show the user a quick guide to claude-music.
 
 ## Instructions
 
@@ -18,7 +18,7 @@ Print the following guide directly (do not run any commands):
 
 ---
 
-**code-music** — background music for your coding sessions
+**claude-music** — background music for your coding sessions
 
 **Playback**
 - `/play [genre]` — Start music (optionally pick a genre)

--- a/skills/list/SKILL.md
+++ b/skills/list/SKILL.md
@@ -7,7 +7,7 @@ effort: low
 allowed-tools: Bash, Read
 ---
 
-This skill is part of the code-music plugin. Only invoke when the user explicitly uses the slash command.
+This skill is part of the claude-music plugin. Only invoke when the user explicitly uses the slash command.
 
 # List Genres
 

--- a/skills/mood/SKILL.md
+++ b/skills/mood/SKILL.md
@@ -5,7 +5,7 @@ model: sonnet
 allowed-tools: Bash, Agent
 ---
 
-This skill is part of the code-music plugin. Only invoke when the user explicitly uses the slash command.
+This skill is part of the claude-music plugin. Only invoke when the user explicitly uses the slash command.
 
 # Mood
 

--- a/skills/mute/SKILL.md
+++ b/skills/mute/SKILL.md
@@ -7,7 +7,7 @@ effort: low
 allowed-tools: Bash
 ---
 
-This skill is part of the code-music plugin. Only invoke when the user explicitly uses the slash command.
+This skill is part of the claude-music plugin. Only invoke when the user explicitly uses the slash command.
 
 # Mute
 

--- a/skills/next/SKILL.md
+++ b/skills/next/SKILL.md
@@ -7,7 +7,7 @@ effort: low
 allowed-tools: Bash
 ---
 
-This skill is part of the code-music plugin. Only invoke when the user explicitly uses the slash command.
+This skill is part of the claude-music plugin. Only invoke when the user explicitly uses the slash command.
 
 # Next Track
 

--- a/skills/pause/SKILL.md
+++ b/skills/pause/SKILL.md
@@ -7,7 +7,7 @@ effort: low
 allowed-tools: Bash
 ---
 
-This skill is part of the code-music plugin. Only invoke when the user explicitly uses the slash command.
+This skill is part of the claude-music plugin. Only invoke when the user explicitly uses the slash command.
 
 # Stop Music
 
@@ -20,7 +20,7 @@ Run `"${CLAUDE_PLUGIN_ROOT}/scripts/music-controller.sh" stop`.
 
 Output format — use this exact markdown structure:
 
-**♪ Code Music · Session Recap**
+**♪ Claude Music · Session Recap**
 
 **This session** — {genre} for {duration_minutes} min, {station_count} station(s)
 

--- a/skills/play/SKILL.md
+++ b/skills/play/SKILL.md
@@ -7,7 +7,7 @@ effort: low
 allowed-tools: Bash
 ---
 
-This skill is part of the code-music plugin. Only invoke when the user explicitly uses the slash command.
+This skill is part of the claude-music plugin. Only invoke when the user explicitly uses the slash command.
 
 # Play Music
 


### PR DESCRIPTION
## Summary
- Updated boilerplate text in 10 skill SKILL.md files (dj, feedback, focus, help, list, mood, mute, next, pause, play)
- Replaced all `code-music` → `claude-music` and `Code Music` → `Claude Music` references
- Includes extra changes in help (project name), feedback (GitHub URL), pause (recap header)

## Test plan
- [x] `grep -rn "code-music\|Code Music"` returns zero matches in all 10 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)