### PR TITLE
Fix macOS watchdog killing player due to TTY detection bug

### DIFF
--- a/scripts/music-controller.sh
+++ b/scripts/music-controller.sh
@@ -314,7 +314,7 @@ find_session_tty() {
     local tty=""
     while [ "$pid" -gt 1 ] 2>/dev/null; do
         tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-        if [ -n "$tty" ] && [ "$tty" != "?" ]; then
+        if [ -n "$tty" ] && [ "$tty" != "?" ] && [ "$tty" != "??" ]; then
             echo "$tty"
             return 0
         fi


### PR DESCRIPTION
## Summary

- On macOS, `ps -o tty=` reports `??` (two question marks) for processes without a controlling terminal, unlike Linux which reports `?` (one). The existing filter only checked for `?`, so `??` passed as a "valid" TTY.
- The watchdog then monitored `/dev/??` which doesn't exist, immediately triggering the "terminal gone" kill path and stopping playback within ~2 seconds.
- Adds `??` to the TTY filter in `find_session_tty()` so it correctly returns no TTY, causing the watchdog to skip monitoring (which is the correct behavior for detached processes).

## Test plan

- [ ] On macOS, start music playback via Claude Code's Bash tool and verify the player is **not** killed after ~2s
- [ ] On Linux, verify existing behavior is unchanged (watchdog still works when a real TTY is present)
- [ ] Verify `find_session_tty` returns failure (exit 1) when run in a detached process on both platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)